### PR TITLE
Added Alternate Credential support and made some changes

### DIFF
--- a/PSCMLib/Collections/Add-CMDeviceToCollection.ps1
+++ b/PSCMLib/Collections/Add-CMDeviceToCollection.ps1
@@ -65,13 +65,14 @@ Function Add-CMDeviceToCollection {
 
     begin {               
         $WmiArgs = @{ NameSpace = "root\SMS\Site_$SiteCode"}
-        $CollectionCount = [pscustomObject]@{'OldCount'a=$null;'NewCount'=$null}
+
+        $CollectionCount = [pscustomObject]@{'OldCount'=$null;'NewCount'=$null}
 
         if ($PSBoundParameters.ContainsKey('CollectionID')){
             $WMIArgs.Add('Filter', "CollectionID = '$CollectionID' and CollectionType='2'")
         }
         
-        if ($PSBoundParameters.ContainsKey('CollectionName')){{
+        if ($PSBoundParameters.ContainsKey('CollectionName')){
             $WMIArgs.Add('Filter', "CollectionName = '$CollectionName' and CollectionType='2'")
         }
         
@@ -80,7 +81,7 @@ Function Add-CMDeviceToCollection {
         }
 
         if ($PSBoundParameters.ContainsKey('Credential')){
-            $WmiArgs.Add(Credential, $Credential)
+            $WmiArgs.Add('Credential', $Credential)
             Write-Verbose "Will be using $($Credential.UserName) for this connection"
         }
         write-debug "test param build out here"

--- a/PSCMLib/Collections/Add-CMDeviceToCollection.ps1
+++ b/PSCMLib/Collections/Add-CMDeviceToCollection.ps1
@@ -20,34 +20,74 @@
     An array of SMS_Resource Objects to add to the collection (must contain both a devicename and ResourceID property)
 .PARAMETER EchoCollectionCount    
     When this switch is present detailed collection count information will be displayed before and after operations
+.PARAMETER ComputerName
+    This command supports operating against remote computers.  Provide the computer name of the SCCM Site Server with this param.
 .PARAMETER Credential
     Provide this credential to use an alternate credential for the WMI Operations
 #>
 Function Add-CMDeviceToCollection {
     [CmdLetBinding()]
     Param(
-        [string]   $CollectionID,
-        [string]   $SiteCode,
-        [parameter(Mandatory=$true, ValueFromPipeline=$true)]
-        $System,
+        
+        [Parameter(Mandatory=$true, 
+                   Position=0,
+                   ParameterSetName='CollNameSet')]
+        [ValidateNotNull()]
+        [ValidateNotNullOrEmpty()]
+        [Alias('Name')] 
+        [string]    $CollectionName,
+        [Parameter(Mandatory=$true, 
+                   Position=0,
+                   ParameterSetName='CollIDSet')]
+        [ValidateNotNull()]
+        [ValidateNotNullOrEmpty()]
+        [Alias('ID')] 
+        [string]    $CollectionID,
+        [parameter(Mandatory=$true,
+                   ParameterSetName = 'CollNameSet')]
+        [parameter(ParameterSetName = 'CollIDSet')]
+        [string]    $SiteCode,
+        [parameter(Mandatory=$true, 
+                   ValueFromPipeline=$true,
+                   ParameterSetName = 'CollNameSet')]
+        [parameter(ParameterSetName = 'CollIDSet')]
+        [string[]]  $System,
         [pscredential]$Credential,
-        [switch]$EchoCollectionCount
+        [parameter(Mandatory=$false, 
+                   ParameterSetName = 'CollNameSet')]
+        [parameter(ParameterSetName = 'CollIDSet')]
+        [ValidateNotNull()]
+        [ValidateNotNullOrEmpty()]
+        [Alias('SMSSiteServerName')] 
+        [string]    $ComputerName, 
+        [switch]    $EchoCollectionCount
     )
 
     begin {               
-        if ($Credential){
-            $WmiArgs = @{ NameSpace = "root\SMS\Site_$SiteCode"; ComputerName = $CMDBServer; Credential = $Credential }
-            Write-Verbose "Will be using $($Credential.UserName) for this connection"
-        }
-        else {
-            $WmiArgs = @{ NameSpace = "root\SMS\Site_$SiteCode"; ComputerName = $CMDBServer}
+        $WmiArgs = @{ NameSpace = "root\SMS\Site_$SiteCode"}
+        $CollectionCount = [pscustomObject]@{'OldCount'a=$null;'NewCount'=$null}
+
+        if ($PSBoundParameters.ContainsKey('CollectionID')){
+            $WMIArgs.Add('Filter', "CollectionID = '$CollectionID' and CollectionType='2'")
         }
         
-        Write-Verbose "Attempting to connect over WMI to $($WmiArgs.ComputerName):\\$($WmiArgs.NameSpace)"
-        $CollectionCount = [pscustomObject]@{'OldCount'=$null;'NewCount'=$null}
-        $CollectionQuery = Get-WmiObject @WMIArgs -Class SMS_Collection -Filter "CollectionID = '$CollectionID' and CollectionType='2'" -ErrorAction Stop 
-        if ($CollectionQuery){
-            Write-Verbose "Resolved Collection $($CollectionQuery.Name) with $($WmiArgs.NameSpace)"
+        if ($PSBoundParameters.ContainsKey('CollectionName')){{
+            $WMIArgs.Add('Filter', "CollectionName = '$CollectionName' and CollectionType='2'")
+        }
+        
+        if ($PSBoundParameters.ContainsKey('ComputerName')){
+            $WmiArgs.Add('ComputerName', $ComputerName)
+        }
+
+        if ($PSBoundParameters.ContainsKey('Credential')){
+            $WmiArgs.Add(Credential, $Credential)
+            Write-Verbose "Will be using $($Credential.UserName) for this connection"
+        }
+        write-debug "test param build out here"
+        
+        $CollectionRef = Get-WmiObject @WMIArgs -Class SMS_Collection -Filter $WMIFilter -ErrorAction Stop 
+        if ($CollectionRef){
+            Write-Verbose "Resolved Collection $($CollectionRef.Name) with $($WmiArgs.NameSpace)"
             $InParams = $CollectionQuery.PSBase.GetMethodParameters('AddMembershipRules')
             Write-Verbose "Retrieving Class Object..."
             $cls = Get-WmiObject @WMIArgs -Class SMS_CollectionRuleDirect -list -ErrorAction Stop       
@@ -58,7 +98,7 @@ Function Add-CMDeviceToCollection {
         }
         
         if ($EchoCollectionCount){
-            $MemberCount = Get-WmiObject @WMIArgs -class 'SMS_Collection' -Filter "CollectionID='$CollectionID'"
+            $MemberCount = Get-WmiObject @WMIArgs -class 'SMS_Collection' -Filter "CollectionID='$($CollectionRef.CollectionID)'"
             $MemberCount.Get()
             $CollectionCount.OldCount = $MemberCount.CollectionRules.Count
             Write-Verbose "$CollectionID direct membership rule count: $($CollectionCount.OldCount)"
@@ -72,15 +112,15 @@ Function Add-CMDeviceToCollection {
             $NewRule.Rulename = $sys.Name
             $Rules += $NewRule.psobject.BaseObject 
         }
-        Write-Verbose "Adding $($Rules.Count) rules to Collection: $CollectionID"
+        Write-Verbose "Adding $($Rules.Count) rules to Collection: $($CollectionID,$CollectionName)"
     }
     end {
         $InParams.CollectionRules += $Rules.psobject.BaseOBject
-        $CollectionQuery.PSBase.InvokeMethod('AddMembershipRules',$InParams,$null) | Out-null
-        $CollectionQuery.RequestRefresh() | out-null
+        $CollectionRef.PSBase.InvokeMethod('AddMembershipRules',$InParams,$null) | Out-null
+        $CollectionRef.RequestRefresh() | out-null
 
         if ($EchoCollectionCount){
-            $MemberCount = Get-WmiObject @WMIArgs -class 'SMS_Collection' -Filter "CollectionID='$CollectionID'" 
+            $MemberCount = Get-WmiObject @WMIArgs -class 'SMS_Collection' -Filter "CollectionID='$($CollectionRef.CollectionID)'"
             $MemberCount.Get()
             $CollectionCount.NewCount = $MemberCount.CollectionRules.Count
             Write-Verbose "$CollectionID direct membership rule count: $($CollectionCount.NewCount)"

--- a/PSCMLib/Collections/Add-CMDeviceToCollection.ps1
+++ b/PSCMLib/Collections/Add-CMDeviceToCollection.ps1
@@ -1,25 +1,68 @@
+<#
+.Synopsis
+   Adds many members to a CM Collection with only one call
+.DESCRIPTION
+   Uses WMI to add many Direct Membership rules to a SCCM Device Collection with just one DB action
+.EXAMPLE
+   Add-CMDeviceToCollection -CollectionID XXX00750 -SiteCode XXX -System $ReadyForMigrationDevices[50..70] -EchoCollectionCount 
+.EXAMPLE
+   Another example of how to use this cmdlet
+.NOTES
+   Author Keith Garner
+          Stephen Owen
 
+    URL   https://keithga.wordpress.com/2018/01/25/a-replacement-for-sccm-add-cmdevicecollectiondirectmembershiprule-powershell-cmdlet/
+.PARAMETER CollectionID
+    The SMS Collection ID to which the devices should be added
+.PARAMETER SITECODE
+    The SMS_XXX SiteCode of the CM Instance
+.PARAMETER SYSTEM
+    An array of SMS_Resource Objects to add to the collection (must contain both a devicename and ResourceID property)
+.PARAMETER EchoCollectionCount    
+    When this switch is present detailed collection count information will be displayed before and after operations
+.PARAMETER Credential
+    Provide this credential to use an alternate credential for the WMI Operations
+#>
 Function Add-CMDeviceToCollection {
-    <#
-
-    https://keithga.wordpress.com/2018/01/25/a-replacement-for-sccm-add-cmdevicecollectiondirectmembershiprule-powershell-cmdlet/
-
-    #>
-
     [CmdLetBinding()]
     Param(
-        [string]   $CollectionName,
+        [string]   $CollectionID,
+        [string]   $SiteCode,
         [parameter(Mandatory=$true, ValueFromPipeline=$true)]
-        $System
+        $System,
+        [pscredential]$Credential,
+        [switch]$EchoCollectionCount
     )
 
-    begin {
-
-        $WmiArgs = Get-CMSiteForWMI
-        $CollectionQuery = Get-WmiObject @WMIArgs -Class SMS_Collection -Filter "Name = '$CollectionName' and CollectionType='2'"
-        $InParams = $CollectionQuery.PSBase.GetMethodParameters('AddMembershipRules')
-        $Cls = [WMIClass]"\\$($WMIArgs.ComputerName)\$($WmiArgs.NameSpace):SMS_CollectionRuleDirect"
-        $Rules = @()
+    begin {               
+        if ($Credential){
+            $WmiArgs = @{ NameSpace = "root\SMS\Site_$SiteCode"; ComputerName = $CMDBServer; Credential = $Credential }
+            Write-Verbose "Will be using $($Credential.UserName) for this connection"
+        }
+        else {
+            $WmiArgs = @{ NameSpace = "root\SMS\Site_$SiteCode"; ComputerName = $CMDBServer}
+        }
+        
+        Write-Verbose "Attempting to connect over WMI to $($WmiArgs.ComputerName):\\$($WmiArgs.NameSpace)"
+        $CollectionCount = [pscustomObject]@{'OldCount'=$null;'NewCount'=$null}
+        $CollectionQuery = Get-WmiObject @WMIArgs -Class SMS_Collection -Filter "CollectionID = '$CollectionID' and CollectionType='2'" -ErrorAction Stop 
+        if ($CollectionQuery){
+            Write-Verbose "Resolved Collection $($CollectionQuery.Name) with $($WmiArgs.NameSpace)"
+            $InParams = $CollectionQuery.PSBase.GetMethodParameters('AddMembershipRules')
+            Write-Verbose "Retrieving Class Object..."
+            $cls = Get-WmiObject @WMIArgs -Class SMS_CollectionRuleDirect -list -ErrorAction Stop       
+            $Rules = @()
+        }
+        else{
+            throw
+        }
+        
+        if ($EchoCollectionCount){
+            $MemberCount = Get-WmiObject @WMIArgs -class 'SMS_Collection' -Filter "CollectionID='$CollectionID'"
+            $MemberCount.Get()
+            $CollectionCount.OldCount = $MemberCount.CollectionRules.Count
+            Write-Verbose "$CollectionID direct membership rule count: $($CollectionCount.OldCount)"
+        }
     }
     process {
         foreach ( $sys in $System ) {
@@ -29,10 +72,19 @@ Function Add-CMDeviceToCollection {
             $NewRule.Rulename = $sys.Name
             $Rules += $NewRule.psobject.BaseObject 
         }
+        Write-Verbose "Adding $($Rules.Count) rules to Collection: $CollectionID"
     }
     end {
         $InParams.CollectionRules += $Rules.psobject.BaseOBject
         $CollectionQuery.PSBase.InvokeMethod('AddMembershipRules',$InParams,$null) | Out-null
         $CollectionQuery.RequestRefresh() | out-null
+
+        if ($EchoCollectionCount){
+            $MemberCount = Get-WmiObject @WMIArgs -class 'SMS_Collection' -Filter "CollectionID='$CollectionID'" 
+            $MemberCount.Get()
+            $CollectionCount.NewCount = $MemberCount.CollectionRules.Count
+            Write-Verbose "$CollectionID direct membership rule count: $($CollectionCount.NewCount)"
+            return $CollectionCount
+        }
     }
 }

--- a/PSCMLib/Collections/Remove-CMResourceFromCollection.ps1
+++ b/PSCMLib/Collections/Remove-CMResourceFromCollection.ps1
@@ -1,24 +1,77 @@
+<#
+.Synopsis
+   Removes many members from a CM Collection with only one call
+.DESCRIPTION
+   Uses WMI to Remove many Direct Membership rules from a SCCM Device Collection with just one DB action
+.EXAMPLE
+   Remove-CMDeviceFromCollection -CollectionID XXX00750 -SiteCode XXX -System $ReadyForMigrationDevices[50..70] -EchoCollectionCount 
 
-Function Remove-CMResourceFromCollection {
-    <#
+   VERBOSE: Attempting to connect over WMI to FOXSCCM01.foxdeploy.local:\\root\SMS\Site_XXX using FoxDeploy\Admin01 credential
+VERBOSE: Resolved Collection PreAssessment_Scan with root\SMS\Site_XXX
+VERBOSE: Retrieving Class Object...
+VERBOSE: XXX00750 direct membership rule count: 22
+VERBOSE: Removing 21 rules from Collection: XXX00750
+VERBOSE: XXX00750 direct membership rule count: 1
 
-    https://keithga.wordpress.com/2018/01/25/a-replacement-for-sccm-add-cmdevicecollectiondirectmembershiprule-powershell-cmdlet/
+OldCount NewCount
+-------- --------
+      22        1
+.NOTES
+   Author Keith Garner
+          Stephen Owen
 
-    #>
-
+    URL   https://keithga.wordpress.com/2018/01/25/a-replacement-for-sccm-add-cmdevicecollectiondirectmembershiprule-powershell-cmdlet/
+.PARAMETER CollectionID
+    The SMS Collection ID to which the devices should be added
+.PARAMETER SITECODE
+    The SMS_XXX SiteCode of the CM Instance
+.PARAMETER SYSTEM
+    An array of SMS_Resource Objects to add to the collection (must contain both a devicename and ResourceID property)
+.PARAMETER EchoCollectionCount    
+    When this switch is present detailed collection count information will be displayed before and after operations
+.PARAMETER Credential
+    Provide this credential to use an alternate credential for the WMI Operations
+#>
+Function Remove-CMDeviceFromCollection {
     [CmdLetBinding()]
     Param(
-        [string]   $CollectionName,
+        [string]   $CollectionID,
+        [string]   $SiteCode,
         [parameter(Mandatory=$true, ValueFromPipeline=$true)]
-        $System
+        $System,
+        [pscredential]$Credential,
+        [Switch]$EchoCollectionCount
     )
 
     begin {
-        $WmiArgs = Get-CMSiteForWMI
-        $CollectionQuery = Get-WmiObject @WMIArgs -Class SMS_Collection -Filter "Name = '$CollectionName' and CollectionType='2'"
-        $InParams = $CollectionQuery.PSBase.GetMethodParameters('DeleteMembershipRules')
-        $Cls = [WMIClass]"\\$($WMIArgs.ComputerName)\$($WmiArgs.NameSpace):SMS_CollectionRuleDirect"
-        $Rules = @()
+        if ($Credential){
+            $WmiArgs = @{ NameSpace = "root\SMS\Site_$SiteCode"; ComputerName = $CMDBServer; Credential = $Credential }
+            Write-Verbose "Will be using $($Credential.UserName) for this connection"
+        }
+        else {
+            $WmiArgs = @{ NameSpace = "root\SMS\Site_$SiteCode"; ComputerName = $CMDBServer}
+        }
+
+        Write-Verbose "Attempting to connect over WMI to $($WmiArgs.ComputerName):\\$($WmiArgs.NameSpace)"
+        $CollectionCount = [pscustomObject]@{'OldCount'=$null;'NewCount'=$null}
+        $CollectionQuery = Get-WmiObject @WMIArgs -Class SMS_Collection -Filter "CollectionID = '$CollectionID' and CollectionType='2'" -ErrorAction Stop 
+        if ($CollectionQuery){
+            Write-Verbose "Resolved Collection $($CollectionQuery.Name) with $($WmiArgs.NameSpace)"
+            $InParams = $CollectionQuery.PSBase.GetMethodParameters('AddMembershipRules')
+            Write-Verbose "Retrieving Class Object..."
+            $cls = Get-WmiObject @WMIArgs -Class SMS_CollectionRuleDirect -list -ErrorAction Stop       
+            $Rules = @()
+        }
+        else{
+            throw
+        }
+
+        if ($EchoCollectionCount){
+            $MemberCount = Get-WmiObject @WMIArgs -class 'SMS_Collection' -Filter "CollectionID='$CollectionID'" 
+            $MemberCount.Get()
+            $CollectionCount.OldCount = $MemberCount.CollectionRules.Count
+            Write-Verbose "$CollectionID direct membership rule count: $($CollectionCount.OldCount)"
+        }
     }
     process {
         foreach ( $sys in $System ) {
@@ -28,10 +81,19 @@ Function Remove-CMResourceFromCollection {
             $NewRule.Rulename = $sys.Name
             $Rules += $NewRule.psobject.BaseObject 
         }
+        Write-Verbose "Removing $($Rules.Count) rules from Collection: $CollectionID"
     }
     end {
         $InParams.CollectionRules += $Rules.psobject.BaseOBject
         $CollectionQuery.PSBase.InvokeMethod('DeleteMembershipRules',$InParams,$null) | Out-null
         $CollectionQuery.RequestRefresh() | out-null
+    
+        if ($EchoCollectionCount){
+            $MemberCount = Get-WmiObject @WMIArgs -class 'SMS_Collection' -Filter "CollectionID='$CollectionID'" 
+            $MemberCount.Get()
+            $CollectionCount.NewCount = $MemberCount.CollectionRules.Count
+            Write-Verbose "$CollectionID direct membership rule count: $($CollectionCount.NewCount)"
+            return $CollectionCount
+        }
     }
 }


### PR DESCRIPTION
Modified all [wmi] accelerator usage to *-WmiObject calls, to allow for using alternate credentials.  

Added new switch -EchoCollection, which will display collection rule count before and after operations by returning a PSCustomObject containing the old and new rule count.  

**Changed to use CollectionID in lieu of CollectionName**- I plan to add an additional parameter set to allow for CollectionName to still work, but for my needs a Collection ID was better.  Wanted to draw attention to this!

Adding additional logging with -Verbose