### PR TITLE
Modified to use Arraylist and added status updates

### DIFF
--- a/PSCMLib/Collections/Add-CMDeviceToCollection.ps1
+++ b/PSCMLib/Collections/Add-CMDeviceToCollection.ps1
@@ -78,7 +78,7 @@ Function Add-CMDeviceToCollection {
         $InParams = $CollectionQuery.PSBase.GetMethodParameters('AddMembershipRules')
         Write-Verbose "Retrieving Class Object SMS_CollectionRuleDirect ..."
         $cls = Get-WmiObject @WMIArgs -Class SMS_CollectionRuleDirect -list -ErrorAction Stop
-        $Rules = @()
+        $Rules = New-Object System.Collections.Arraylist
 
         $MemberCount = Get-WmiObject @WMIArgs -Class SMS_Collection -ErrorAction Stop -Filter $Filter
         $MemberCount.Get()
@@ -94,7 +94,10 @@ Function Add-CMDeviceToCollection {
                 $NewRule.ResourceClassName = "SMS_R_System"
                 $NewRule.ResourceID = $sys.ResourceID
                 $NewRule.Rulename = $sys.Name
-                $Rules += $NewRule.psobject.BaseObject 
+                $Counter = $Rules.Add($NewRule.psobject.BaseObject)
+                if (($counter % 1000) -eq 0){
+                    Write-Verbose "Processing rule $counter of $($System.Count)"
+                }
             }
         }
     }


### PR DESCRIPTION
Using an Arryalist is incredibly fast in PowerShell, much better than += when working with big sets of items due to PowerShell's immutable variables.  Also added a Status update as the cmdlet is quiet while doing a lot of work.  Will now display something like this:
 ````
processing rule 103000 of 112270
processing rule 104000 of 112270
processing rule 105000 of 112270
processing rule 106000 of 112270
processing rule 107000 of 112270
````